### PR TITLE
You forgot to rename channels to inputs for iso.nix

### DIFF
--- a/iso.nix
+++ b/iso.nix
@@ -1,5 +1,5 @@
 # Configuration for (re)installing NixOS.
-{ channels
+{ inputs
 }:
 let
   system = "x86_64-linux";


### PR DESCRIPTION
Was browsing through your config (thanks for making it public!) and noticed a small refactor bug, so I thought it best to let you know.